### PR TITLE
v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.0.2]
+
+### Changed
+
+- Fixed a bug where `Array.concat(Deep)`, `Dictionary.merge(Deep)` and `Set.merge` would not accept holes (`nil` values) in their arguments. This would cause the function to stop processing further arguments once it found a `nil` value.
+- Fixed a bug where `Array.insert` would not insert the element at the correct index. An index of `0` will now insert the element at the end of the array. `length+1` will also insert the element at the end of the array. `length+2` (or greater) will be ignored, and the original array will be returned.
+- Bumped tooling versions:
+  - rojo to v7.1.1
+  - stylua to v0.13.1
+  - selene to v0.17.0
+
 ## [0.0.1]
 
 ### Added

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,6 +1,6 @@
 [tools]
-rojo = { source = "rojo-rbx/rojo", version = "=7.0.0" }
+rojo = { source = "rojo-rbx/rojo", version = "=7.1.1" }
 run-in-roblox = { source = "rojo-rbx/run-in-roblox", version = "=0.3.0" }
 wally = { source = "upliftgames/wally", version = "=0.3.1" }
-stylua = { source = "johnnymorganz/stylua", version = "=0.12.2" }
-selene = { source = "kampfkarren/selene", version = "=0.16.0" }
+stylua = { source = "johnnymorganz/stylua", version = "=0.13.1" }
+selene = { source = "kampfkarren/selene", version = "=0.17.0" }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/sift",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Immutable data library for Luau",
   "main": "out/init.lua",
   "types": "out/index.d.ts",

--- a/src/Array/concat.lua
+++ b/src/Array/concat.lua
@@ -23,10 +23,12 @@ local None = require(Sift.None)
 	local new = Concat(table1, table2) -- { 1, 2, 3, 4, 5, 6 }
 	```
 ]=]
-local function concat<T>(...: { T }): { T }
+local function concat<T>(...: any): { T }
 	local result = {}
 
-	for _, array in ipairs({ ... }) do
+	for arrayIndex = 1, select("#", ...) do
+		local array = select(arrayIndex, ...)
+
 		if type(array) ~= "table" then
 			continue
 		end

--- a/src/Array/concat.lua
+++ b/src/Array/concat.lua
@@ -7,7 +7,7 @@ local None = require(Sift.None)
 	@function concat
 	@within Array
 
-	@param ... ...{T} -- The arrays to concatenate.
+	@param ... ...any -- The arrays to concatenate.
 	@return {T} -- The concatenated array.
 
 	Joins multiple arrays together into a single array.

--- a/src/Array/concat.spec.lua
+++ b/src/Array/concat.spec.lua
@@ -24,6 +24,17 @@ return function()
 		expect(#new).to.equal(0)
 	end)
 
+	it("should accept nil values", function()
+		local new = Concat(nil, { 1, 2, 3 })
+		local new2 = Concat({ 1, 2, 3 }, nil)
+
+		expect(new).to.be.a("table")
+		expect(#new).to.equal(3)
+
+		expect(new2).to.be.a("table")
+		expect(#new2).to.equal(3)
+	end)
+
 	it("should not copy the nested arrays", function()
 		local table1 = { 1, 2, { 3, 4 } }
 		local table2 = { 5, 6, { 7, 8 } }

--- a/src/Array/concatDeep.lua
+++ b/src/Array/concatDeep.lua
@@ -25,10 +25,12 @@ local None = require(Sift.None)
 	local new = ConcatDeep(table1, table2) -- { 1, 2, { 3, 4 }, 5, 6, { 7, 8 } }
 	```
 ]=]
-local function concatDeep<T>(...: { T }): { T }
+local function concatDeep<T>(...: any): { T }
 	local result = {}
 
-	for _, array in ipairs({ ... }) do
+	for arrayIndex = 1, select("#", ...) do
+		local array = select(arrayIndex, ...)
+
 		if type(array) ~= "table" then
 			continue
 		end

--- a/src/Array/concatDeep.lua
+++ b/src/Array/concatDeep.lua
@@ -8,7 +8,7 @@ local None = require(Sift.None)
 	@function concatDeep
 	@within Array
 
-	@param ... ...{T} -- The arrays to concatenate.
+	@param ... ...any -- The arrays to concatenate.
 	@return {T} -- The concatenated array.
 
 	Joins multiple arrays together into a single array, with deep copies of all

--- a/src/Array/concatDeep.spec.lua
+++ b/src/Array/concatDeep.spec.lua
@@ -24,6 +24,17 @@ return function()
 		expect(#new).to.equal(0)
 	end)
 
+	it("should accept nil values", function()
+		local new = ConcatDeep(nil, { 1, 2, 3 })
+		local new2 = ConcatDeep({ 1, 2, 3 }, nil)
+
+		expect(new).to.be.a("table")
+		expect(#new).to.equal(3)
+
+		expect(new2).to.be.a("table")
+		expect(#new2).to.equal(3)
+	end)
+
 	it("should join multiple arrays, copying nested arrays", function()
 		local table1 = { 1, 2, { 3, 4 } }
 		local table2 = { 5, 6, { 7, 8 } }

--- a/src/Array/insert.lua
+++ b/src/Array/insert.lua
@@ -10,6 +10,8 @@
 
   Inserts the given values into an array at the given index, shifting all values after it to the right. If the index is negative (or 0), it is counted from the end of the array.
 
+	If the index to insert at is out of range, the array is not modified.
+
   ```lua
   local array = { 1, 2, 3 }
 
@@ -20,7 +22,16 @@ local function insert<T>(array: { T }, index: number, ...: T): { T }
 	local length = #array
 
 	if index < 1 then
-		index += length
+		index += length + 1
+	end
+
+	if index > length then
+		if index > length + 1 then
+			return array
+		end
+
+		index = length + 1
+		length += 1
 	end
 
 	local result = {}

--- a/src/Array/insert.spec.lua
+++ b/src/Array/insert.spec.lua
@@ -22,15 +22,36 @@ return function()
 	it("should accept negative indices", function()
 		local array = { 1, 2, 3 }
 
-		local newArray = Insert(array, 0, 4, 5) -- { 1, 2, 4, 5, 3 }
+		local newArray = Insert(array, 0, 4, 5) -- { 1, 2, 3, 4, 5 }
+		local newArray2 = Insert(array, -1, 4, 5) -- { 1, 2, 4, 5, 3 }
 
 		expect(newArray).to.be.a("table")
 		expect(#newArray).to.equal(5)
+		expect(newArray[5]).to.equal(5)
 
-		expect(newArray[1]).to.equal(1)
-		expect(newArray[2]).to.equal(2)
-		expect(newArray[3]).to.equal(4)
-		expect(newArray[4]).to.equal(5)
-		expect(newArray[5]).to.equal(3)
+		expect(newArray2).to.be.a("table")
+		expect(#newArray2).to.equal(5)
+		expect(newArray2[3]).to.equal(4)
+		expect(newArray2[5]).to.equal(3)
+	end)
+
+	it("should accept length+1", function()
+		local array = { 1, 2, 3 }
+
+		local newArray = Insert(array, 4, 4, 5) -- { 1, 2, 3, 4, 5 }
+		local newArray2 = Insert(array, 5, 4) -- { 1, 2, 3 }
+		local newArray3 = Insert(array, 0, 4) -- { 1, 2, 3, 4 }
+
+		expect(newArray).to.be.a("table")
+		expect(#newArray).to.equal(5)
+		expect(newArray[5]).to.equal(5)
+
+		expect(newArray2).to.be.a("table")
+		expect(#newArray2).to.equal(3)
+		expect(newArray2[3]).to.equal(3)
+
+		expect(newArray3).to.be.a("table")
+		expect(#newArray3).to.equal(4)
+		expect(newArray3[4]).to.equal(4)
 	end)
 end

--- a/src/Dictionary/merge.lua
+++ b/src/Dictionary/merge.lua
@@ -7,7 +7,7 @@ local None = require(Sift.None)
   @function merge
   @within Dictionary
 
-  @param dictionaries? ...U -- The dictionaries to merge.
+  @param dictionaries? ...any -- The dictionaries to merge.
   @return T -- The merged dictionary.
 
   Merges the given dictionaries into a single dictionary. If the

--- a/src/Dictionary/merge.lua
+++ b/src/Dictionary/merge.lua
@@ -24,10 +24,12 @@ local None = require(Sift.None)
   local merged = Merge(dictionary1, dictionary2) -- { hello = "roblox", goodbye = "goodbye" }
   ```
 ]=]
-local function merge<T>(...: { [any]: any }?): T
+local function merge<T>(...: any): T
 	local result = {}
 
-	for _, dictionary in ipairs({ ... }) do
+	for dictionaryIndex = 1, select("#", ...) do
+		local dictionary = select(dictionaryIndex, ...)
+
 		if type(dictionary) ~= "table" then
 			continue
 		end

--- a/src/Dictionary/merge.spec.lua
+++ b/src/Dictionary/merge.spec.lua
@@ -31,11 +31,17 @@ return function()
 		local dictionary1 = { hello = "roblox", goodbye = "world" }
 
 		local merged = Merge(dictionary1, nil)
+		local merged2 = Merge(nil, dictionary1)
 
 		expect(merged).to.be.a("table")
 
 		expect(merged.hello).to.equal("roblox")
 		expect(merged.goodbye).to.equal("world")
+
+		expect(merged2).to.be.a("table")
+
+		expect(merged2.hello).to.equal("roblox")
+		expect(merged2.goodbye).to.equal("world")
 	end)
 
 	it("should remove values set to None", function()

--- a/src/Dictionary/mergeDeep.lua
+++ b/src/Dictionary/mergeDeep.lua
@@ -25,10 +25,12 @@ local copyDeep = require(script.Parent.copyDeep)
 	local merged = MergeDeep(dictionary1, dictionary2) -- { hello = "roblox", goodbye = { world = "world" } }
 	```
 ]=]
-local function mergeDeep<T>(...: { [any]: any }?): T
+local function mergeDeep<T>(...: any): T
 	local result = {}
 
-	for _, dictionary in ipairs({ ... }) do
+	for dictionaryIndex = 1, select("#", ...) do
+		local dictionary = select(dictionaryIndex, ...)
+
 		if type(dictionary) ~= "table" then
 			continue
 		end

--- a/src/Dictionary/mergeDeep.lua
+++ b/src/Dictionary/mergeDeep.lua
@@ -8,7 +8,7 @@ local copyDeep = require(script.Parent.copyDeep)
 	@function mergeDeep
 	@within Dictionary
 
-	@param dictionaries? ...U -- The dictionaries to merge.
+	@param dictionaries? ...any -- The dictionaries to merge.
 	@return T -- The merged dictionary.
 
 	Merges the given dictionaries into a single dictionary. If the

--- a/src/Dictionary/mergeDeep.spec.lua
+++ b/src/Dictionary/mergeDeep.spec.lua
@@ -31,11 +31,17 @@ return function()
 		local dictionary1 = { hello = "roblox", goodbye = { world = "world" } }
 
 		local merged = MergeDeep(dictionary1, nil)
+		local merged2 = MergeDeep(nil, dictionary1)
 
 		expect(merged).to.be.a("table")
 
 		expect(merged.hello).to.equal("roblox")
 		expect(merged.goodbye.world).to.equal("world")
+
+		expect(merged2).to.be.a("table")
+
+		expect(merged2.hello).to.equal("roblox")
+		expect(merged2.goodbye.world).to.equal("world")
 	end)
 
 	it("should remove values set to None", function()

--- a/src/Set/merge.lua
+++ b/src/Set/merge.lua
@@ -3,7 +3,7 @@
   @function merge
   @within Set
 
-  @param ... ...{ [any]: boolean } -- The sets to merge.
+  @param ... ...any -- The sets to merge.
   @return { [T]: boolean } -- The merged set.
 
   Combines one or more sets into a single set.

--- a/src/Set/merge.lua
+++ b/src/Set/merge.lua
@@ -17,10 +17,16 @@
   local merge = Merge(set1, set2) -- { hello = true, world = true, cat = true, dog = true }
   ```
 ]=]
-local function merge<T>(...: { [any]: boolean }): { [T]: boolean }
+local function merge<T>(...: any): { [T]: boolean }
 	local result = {}
 
-	for _, set in ipairs({ ... }) do
+	for setIndex = 1, select("#", ...) do
+		local set = select(setIndex, ...)
+
+		if type(set) ~= "table" then
+			continue
+		end
+
 		for key, _ in pairs(set) do
 			result[key] = true
 		end

--- a/src/Set/merge.spec.lua
+++ b/src/Set/merge.spec.lua
@@ -14,4 +14,20 @@ return function()
 		expect(newSet.panda).to.equal(true)
 		expect(newSet.cat).to.equal(true)
 	end)
+
+	it("should accept nil values", function()
+		local set = { hello = true, world = true }
+		local otherSet = { panda = true, cat = true }
+
+		local newSet = merge(set, nil, otherSet)
+		local newSet2 = merge(nil, set, otherSet)
+
+		expect(newSet).to.be.a("table")
+		expect(newSet.hello).to.equal(true)
+		expect(newSet.panda).to.equal(true)
+
+		expect(newSet2).to.be.a("table")
+		expect(newSet2.cat).to.equal(true)
+		expect(newSet2.world).to.equal(true)
+	end)
 end

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "csqrl/sift"
 description = "Immutable data library for Luau"
-version = "0.0.1"
+version = "0.0.2"
 license = "MIT"
 author = "csqrl (https://csqrl.dev)"
 registry = "https://github.com/upliftgames/wally-index"


### PR DESCRIPTION
### Handle Holes in Arguments

Patched an issue in `Array.concat(Deep)`, `Dictionary.merge(Deep)` and `Set.merge` where they would stop at a `nil` value in the arguments. This closes #3.

This is because, when using `ipairs`, it automatically assumes the end of the array has been reached when it hits a `nil` value.

The new implementation uses `select` to process the vararg (`...`) in order to continue processing even if a `nil` value is present.

### Out of Bound Indices

`Array.insert` will now properly handle out of bound indices.

An index of `0` will cause items to be inserted at the end of the array (since arrays are 1-indexed in Luau).

An index of `length+1` will also allow values to be inserted at the end of the array. Indices of `length+2` or greater will be ignored and return the original array (I'm open to changing this behaviour to throw if requested!).

### Bump Package Versions

- Bumped `package.json` to v0.0.2
- Bumped `wally.toml` to v0.0.2

### Bump Tooling Versions

- Bump rojo to v7.1.1
- Bump stylua to v0.13.1
- Bump selene to v0.17.0