### PR TITLE
Update update.lua documentation

### DIFF
--- a/src/Array/update.lua
+++ b/src/Array/update.lua
@@ -18,7 +18,7 @@ end
 	@within Array
 
 	@param array {T} -- The array to update.
-	@param index {number} -- The index to update.
+	@param index number -- The index to update.
 	@param updater? (value: T, index: number) -> T -- The updater function.
 	@param callback? (index: number) -> T -- The callback function.
 	@return {T} -- The updated array.


### PR DESCRIPTION
Index was denoted as an array of numbers, rather than just a number. I know it's quite the pedantic pull, but I noticed it while reading the documentation, it bugged my OCD, and it was a quick edit.