### PR TITLE
feat(dictionary): add withKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.6]
+
+### Added
+
+- `Dictionary.withKeys` by @sasial-dev to restrict what keys can appear in a given dictionary.
+
 ## [0.0.5]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rbxts/sift",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Immutable data library for Luau",
   "main": "out/init.lua",
   "types": "out/index.d.ts",

--- a/src/Dictionary.d.ts
+++ b/src/Dictionary.d.ts
@@ -4,7 +4,7 @@ import {
   ObjectFromKeyValueArrays,
   ObjectKey,
   ReadonlyDeep,
-  TryIndex,
+  TryIndex
 } from "./Util"
 
 declare namespace SiftDictionary {
@@ -153,6 +153,11 @@ declare namespace SiftDictionary {
       }) & { [key in K]: X }
 
   export function values<T extends object>(dictionary: T): T[keyof T][]
+
+  export function withKeys<T extends object, K extends keyof T>(
+    dictionary: T,
+    ...keys: K[]
+  ): Pick<T, K>
 
   // Aliases
   export { merge as join, mergeDeep as joinDeep }

--- a/src/Dictionary/init.lua
+++ b/src/Dictionary/init.lua
@@ -42,6 +42,7 @@ local Dictionary = {
 	some = require(script.some),
 	update = require(script.update),
 	values = require(script.values),
+	withKeys = require(script.withKeys),
 }
 
 Dictionary.join = Dictionary.merge

--- a/src/Dictionary/withKeys.lua
+++ b/src/Dictionary/withKeys.lua
@@ -1,0 +1,29 @@
+--!strict
+
+--[=[
+  @function withKeys
+  @within Dictionary
+
+  @param dictionary {[K]: V} -- The dictionary to select the keys from.
+  @param keys ...K -- The keys to keep.
+  @return {[K]: V} -- The dictionary with only the given keys.
+
+  Returns a dictionary with the given keys.
+
+  ```lua
+  local dictionary = { hello = "world", cat = "meow", dog = "woof", unicorn = "rainbow" }
+
+  local withoutCatDog = WithKeys(dictionary, "cat", "dog") -- { cat = "meow", dog = "woof" }
+  ```
+]=]
+local function withKeys<K, V>(dictionary: { [K]: V }, ...: K): { [K]: V }
+	local result = {}
+
+	for _, key in ipairs({ ... }) do
+		result[key] = dictionary[key]
+	end
+
+	return result
+end
+
+return withKeys

--- a/src/Dictionary/withKeys.spec.lua
+++ b/src/Dictionary/withKeys.spec.lua
@@ -1,0 +1,29 @@
+return function()
+	local WithKeys = require(script.Parent.withKeys)
+
+	it("should return a new dictionary with the given keys kept", function()
+		local dictionary = { hello = "world", cat = "meow", dog = "woof", unicorn = "rainbow" }
+
+		local newDictionary = WithKeys(dictionary, "cat", "dog")
+
+		expect(newDictionary).to.be.a("table")
+
+		expect(newDictionary.hello).to.equal(nil)
+		expect(newDictionary.cat).to.equal("meow")
+		expect(newDictionary.dog).to.equal("woof")
+		expect(newDictionary.unicorn).to.equal(nil)
+	end)
+
+	it("should not modify the original dictionary", function()
+		local dictionary = { hello = "world", cat = "meow", dog = "woof", unicorn = "rainbow" }
+
+		WithKeys(dictionary, "cat", "dog")
+
+		expect(dictionary).to.be.a("table")
+
+		expect(dictionary.hello).to.equal("world")
+		expect(dictionary.cat).to.equal("meow")
+		expect(dictionary.dog).to.equal("woof")
+		expect(dictionary.unicorn).to.equal("rainbow")
+	end)
+end

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "csqrl/sift"
 description = "Immutable data library for Luau"
-version = "0.0.5"
+version = "0.0.6"
 license = "MIT"
 author = "csqrl (https://csqrl.dev)"
 registry = "https://github.com/upliftgames/wally-index"


### PR DESCRIPTION
A small little PR to add a utility function, `withKeys`.

* Lua functions are tested
* TS types are tested

This is useful for things like sending data from rodux into a database (removing action type and other meta field)

Code sample: (note I wrote this in the PR description so may not compile!)
```ts
import { keys } from 'ts-transformer-keys';

interface Props {
  id: string;
  name: string;
  age: number;
}

interface PropsWithExtraFields extends Props {
  foo: string;
  bar: string;
}

const dummyObject: PropsWithExtraFields = {
  id: "ABC-1234",
  name: "sasial-dev",
  age: -1,
  foo: "bar",
  bar: "foo"
}

const keysOfProps = keys<Props>();
console.log(WithKeys(dummyObject, ...keysOfProps))
// { id: "ABC-1234", name: "sasial-dev", age: -1 }
```