### PR TITLE
fix: allow Dictionary.map to return undefined

### DIFF
--- a/src/Dictionary.d.ts
+++ b/src/Dictionary.d.ts
@@ -77,14 +77,14 @@ declare namespace SiftDictionary {
       value: T[K],
       key: K,
       dictionary: Readonly<T>
-    ) => LuaTuple<[newValue: MV, newKey: MK]>
+    ) => LuaTuple<[newValue: MV, newKey: MK]> | undefined
   ): {
     [key in MK]: MV
   }
 
   export function map<T extends object, K extends keyof T, MV>(
     dictionary: T,
-    mapper: (value: T[K], key: K, dictionary: Readonly<T>) => MV
+    mapper: (value: T[K], key: K, dictionary: Readonly<T>) => MV | undefined
   ): {
     [key in K]: MV
   }


### PR DESCRIPTION
returning undefined allows you to quickly filter a dictionary 

Dictionary.filter can filter dictionaries, but then you cant map