### PR TITLE
Allow reduce and reduceRight to work on falsy values

### DIFF
--- a/src/Array/reduce.lua
+++ b/src/Array/reduce.lua
@@ -32,7 +32,7 @@ local function reduce<T, U>(
 	local result = initReduction
 	local start = 1
 
-	if not result then
+	if result == nil then
 		result = array[1]
 		start = 2
 	end

--- a/src/Array/reduce.spec.lua
+++ b/src/Array/reduce.spec.lua
@@ -20,4 +20,14 @@ return function()
 
 		expect(reduced).to.equal(-4)
 	end)
+
+	it("should reduce the array, even if the array has a falsy initial value", function()
+		local array = { true, false, false }
+
+		local reduced = Reduce(array, function(accumulator, value)
+			return accumulator or value
+		end, false)
+
+		expect(reduced).to.equal(true)
+	end)
 end

--- a/src/Array/reduceRight.lua
+++ b/src/Array/reduceRight.lua
@@ -33,7 +33,7 @@ local function reduceRight<T, U>(
 	local result = initReduction
 	local start = #array
 
-	if not result then
+	if result == nil then
 		result = array[start]
 		start -= 1
 	end

--- a/src/Array/reduceRight.spec.lua
+++ b/src/Array/reduceRight.spec.lua
@@ -20,4 +20,14 @@ return function()
 
 		expect(reduced).to.equal(0)
 	end)
+
+	it("should reduce the array from the right, even if the array has a falsy initial value", function()
+		local array = { true, false, true }
+
+		local reduced = ReduceRight(array, function(accumulator, value)
+			return accumulator or value
+		end, false)
+
+		expect(reduced).to.equal(true)
+	end)
 end


### PR DESCRIPTION
Had a problem where I was trying to detect state change by using an array of results returned by setter functions. Essentially,
```
if Sift.Array.reduce(results :: {boolean}, function(accumulator, changed)
  return accumulator or changed
end, false) then
  -- something changed
end
```

Found out that it assumed the initial value to not be a truthy value. Changed it to compare directly to nil instead.